### PR TITLE
Make UnitType nominally typed

### DIFF
--- a/src/util/Unit.ts
+++ b/src/util/Unit.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface UnitType {}
+export interface UnitType {
+	readonly type: unique symbol
+}
 
 const unitMeta: LuaMetatable<UnitType> = {};
 unitMeta.__eq = () => true;


### PR DESCRIPTION
Give the UnitType a nominal type identity to make the only way of constructing a unit with unit()