### PR TITLE
Fix Iterator.count() incrementing number result by 1

### DIFF
--- a/src/classes/Iterator.ts
+++ b/src/classes/Iterator.ts
@@ -48,7 +48,7 @@ export class Iterator<T extends defined> {
 
 	public count(): number {
 		this.consume();
-		let i = 0;
+		let i = -1;
 		do {
 			i++;
 		} while (this.nextItem().isSome());

--- a/src/classes/Iterator.ts
+++ b/src/classes/Iterator.ts
@@ -48,10 +48,10 @@ export class Iterator<T extends defined> {
 
 	public count(): number {
 		this.consume();
-		let i = -1;
-		do {
+		let i = 0;
+		while (this.nextItem().isSome()) {
 			i++;
-		} while (this.nextItem().isSome());
+		}
 		return i;
 	}
 


### PR DESCRIPTION
The result from iterator's count method is always being incremented by 1. Looks like the code in `do while` is being executed before its assertion.